### PR TITLE
Adds support for SOAP1.2

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires 'perl', '5.008005';
 
 requires 'Dancer2';
 requires 'XML::Compile::SOAP';
+requires 'XML::Compile::SOAP12';
 requires 'XML::Compile::WSDL11';
 requires 'XML::Compile::SOAP::Daemon';
 

--- a/lib/XML/Compile/SOAP/Daemon/Dancer2.pm
+++ b/lib/XML/Compile/SOAP/Daemon/Dancer2.pm
@@ -11,6 +11,7 @@ use Carp;
 use XML::Compile::SOAP::Daemon::Dancer2::Handler;
 use XML::Compile::WSDL11;
 use XML::Compile::SOAP11;
+use XML::Compile::SOAP12;
 
 sub get_implementation {
     my ( $class_name, $dsl ) = @_;


### PR DESCRIPTION
Trying to load SOAP1.2 namespace throw the below error

```
error: wsdl namespace http://schemas.xmlsoap.org/wsdl/soap12/ not loaded
```

using `XML::Compile::SOAP12` loads the missing namespace in `XML::Compile::WSDL11`
